### PR TITLE
feat: Open first data tree node by default

### DIFF
--- a/script.js
+++ b/script.js
@@ -15,6 +15,14 @@ document.addEventListener('DOMContentLoaded', () => {
                 buildAccordion(data, container);
                 // Then attach the now-async event listeners
                 attachEventListeners();
+
+                // --- START VAN DE WIJZIGING ---
+                // Open de eerste (hoofd)node door een klik te simuleren
+                const firstButton = container.querySelector('.accordion-button');
+                if (firstButton) {
+                    firstButton.click();
+                }
+                // --- EINDE VAN DE WIJZIGING ---
             } else {
                 container.innerHTML = '<p>Geen data gevonden.</p>';
             }


### PR DESCRIPTION
This change ensures that the first node of the data tree is automatically opened when the page loads. This is achieved by programmatically triggering a click on the first accordion button after the accordion has been initialized.